### PR TITLE
Refactor vcr logic when a matched stub exists

### DIFF
--- a/R/adapter.R
+++ b/R/adapter.R
@@ -112,12 +112,13 @@ Adapter <- R6::R6Class("Adapter",
         # generate response
         # VCR: recordable/ignored
 
-        if (vcr_loaded()) {
-          cas <- vcr::current_cassette()
-          if (length(cas$previously_recorded_interactions()) == 0) {
-            # using vcr, but no recorded interactions to the cassette yet
-            # use RequestHandler - gets current cassette & record interaction
-            resp <- private$request_handler(req)$handle()
+        if (vcr_cassette_inserted()) {
+          # use RequestHandler - gets current cassette & record interaction
+          resp <- private$request_handler(req)$handle()
+
+          # if written to disk, see if we should modify file path
+          if (self$client == "crul" && is.character(resp$content)) {
+            resp <- private$update_vcr_disk_path(resp)
           }
         
         # no vcr
@@ -127,18 +128,6 @@ Adapter <- R6::R6Class("Adapter",
           resp <- private$add_response_sequences(ss, resp)
         }
 
-        # if vcr loaded: record http interaction into vcr namespace
-        # VCR: recordable/stubbed_by_vcr ??
-        if (vcr_loaded()) {
-          # get current cassette
-          cas <- vcr::current_cassette()
-          resp <- private$request_handler(req)$handle()
-          
-          # if written to disk, see if we should modify file path
-          if (self$client == "crul" && is.character(resp$content)) {
-            resp <- private$update_vcr_disk_path(resp)
-          }
-        } # vcr is not loaded, skip
 
       # request is not in cache but connections are allowed
       } else if (webmockr_net_connect_allowed(uri = private$pluck_url(req))) {

--- a/R/adapter.R
+++ b/R/adapter.R
@@ -112,7 +112,7 @@ Adapter <- R6::R6Class("Adapter",
         # generate response
         # VCR: recordable/ignored
 
-        if ("package:vcr" %in% search()) {
+        if (vcr_loaded()) {
           cas <- vcr::current_cassette()
           if (length(cas$previously_recorded_interactions()) == 0) {
             # using vcr, but no recorded interactions to the cassette yet
@@ -129,7 +129,7 @@ Adapter <- R6::R6Class("Adapter",
 
         # if vcr loaded: record http interaction into vcr namespace
         # VCR: recordable/stubbed_by_vcr ??
-        if ("package:vcr" %in% search()) {
+        if (vcr_loaded()) {
           # get current cassette
           cas <- vcr::current_cassette()
           resp <- private$request_handler(req)$handle()
@@ -150,7 +150,7 @@ Adapter <- R6::R6Class("Adapter",
 
         # if vcr loaded: record http interaction into vcr namespace
         # VCR: recordable
-        if ("package:vcr" %in% search()) {
+        if (vcr_loaded()) {
           
           # if written to disk, see if we should modify file path
           if (self$client == "crul" && is.character(resp$content)) {
@@ -185,7 +185,7 @@ Adapter <- R6::R6Class("Adapter",
       } else {
         # throw vcr error: should happen when user not using
         #  use_cassette or insert_cassette
-        if ("package:vcr" %in% search()) {
+        if (vcr_loaded()) {
           private$request_handler(req)$handle()
         }
 

--- a/R/zzz.R
+++ b/R/zzz.R
@@ -177,3 +177,16 @@ last <- function(x) {
   if (length(x) == 0) return(list())
   x[[length(x)]]
 }
+
+
+vcr_loaded <- function() {
+  "package:vcr" %in% search()
+}
+
+# check whether a cassette is inserted without assuming vcr is installed
+vcr_cassette_inserted <- function() {
+  if (vcr_loaded()) {
+    return(length(vcr::current_cassette()) > 0)
+  }
+  return(FALSE)  
+}

--- a/tests/testthat/test-CrulAdapter.R
+++ b/tests/testthat/test-CrulAdapter.R
@@ -35,6 +35,31 @@ test_that("build_crul_request/response fail well", {
   expect_error(build_crul_response(), "argument \"resp\" is missing")
 })
 
+test_that("CrulAdapter: works when vcr is loaded but no cassette is inserted", {
+  skip_on_cran()
+  skip_if_not_installed("vcr")
+  
+  webmockr::enable(adapter = "crul")
+  on.exit({
+    webmockr::disable(adapter = "crul")
+    unloadNamespace("vcr")
+  })
+  
+  stub_request("get", "https://httpbin.org/get")
+  library("vcr")
+  
+  # works when no cassette is loaded
+  cli <- crul::HttpClient$new("https://httpbin.org")
+  
+  expect_silent(x <- cli$get("get"))
+  expect_is(x, "HttpResponse")
+
+  # works when empty cassette is loaded
+  vcr::vcr_configure(dir = getwd())
+  vcr::insert_cassette("empty")
+  expect_silent(x <- cli$get("get"))
+  expect_is(x, "HttpResponse")
+})
 
 context("CrulAdapter - with real data")
 test_that("CrulAdapter works", {

--- a/tests/testthat/test-HttrAdapter.R
+++ b/tests/testthat/test-HttrAdapter.R
@@ -38,6 +38,30 @@ test_that("build_httr_request/response fail well", {
   expect_error(build_httr_response(), "argument \"req\" is missing")
 })
 
+test_that("HttrAdapter: works when vcr is loaded but no cassette is inserted", {
+  skip_on_cran()
+  skip_if_not_installed("vcr")
+  
+  webmockr::enable(adapter = "httr")
+  on.exit({
+    webmockr::disable(adapter = "httr")
+    unloadNamespace("vcr")
+  })
+  
+  stub_request("get", "https://httpbin.org/get")
+  library("vcr")
+  
+  # works when no cassette is loaded
+  expect_silent(x <- httr::GET("https://httpbin.org/get"))
+  expect_is(x, "response")
+  
+  # # works when empty cassette is loaded
+  vcr::vcr_configure(dir = tempdir())
+  vcr::insert_cassette("empty")
+  expect_silent(x <- httr::GET("https://httpbin.org/get"))
+  expect_is(x, "response")
+})
+
 # library(httr)
 # z <- GET("https://httpbin.org/get")
 # httr_obj <- z$request


### PR DESCRIPTION
Updates logic within `handle_request()` to skip all vcr-related code *unless* a cassette is actually inserted.  This fixes #86, which resulted from attempting to call a `Casette` method (`previously_recorded_interactions()`) even when no cassette was present. 

This also:

* consolidates the two vcr-related code blocks within `request_is_in_cache(request_signature)`
* no longer retrieves the cassette or checks to see whether any recordings are detected

Originally [block 1](https://github.com/ropensci/webmockr/blob/359574989d9e9d802fdd616d6bdc4a645c46092b/R/adapter.R#L115-L121) would call the vcr `request_handler()` only if the cassette was empty but then [block 2](https://github.com/ropensci/webmockr/blob/359574989d9e9d802fdd616d6bdc4a645c46092b/R/adapter.R#L132-L140) would call `request_handler()` regardless, and thus appears redundant. 

Only spelling this out in case I'm missing something.

Additionally:

* adds tests to check for the bug described in #86
* adds `vcr_loaded()` and `vcr_cassette_inserted()` helper functions
