### PR TITLE
cleanup after new adapter tests (fixes #89)

### DIFF
--- a/tests/testthat/test-CrulAdapter.R
+++ b/tests/testthat/test-CrulAdapter.R
@@ -55,9 +55,10 @@ test_that("CrulAdapter: works when vcr is loaded but no cassette is inserted", {
   expect_is(x, "HttpResponse")
 
   # works when empty cassette is loaded
-  vcr::vcr_configure(dir = getwd())
+  vcr::vcr_configure(dir = tempdir())
   vcr::insert_cassette("empty")
   expect_silent(x <- cli$get("get"))
+  vcr::eject_cassette("empty")
   expect_is(x, "HttpResponse")
 })
 

--- a/tests/testthat/test-HttrAdapter.R
+++ b/tests/testthat/test-HttrAdapter.R
@@ -59,6 +59,7 @@ test_that("HttrAdapter: works when vcr is loaded but no cassette is inserted", {
   vcr::vcr_configure(dir = tempdir())
   vcr::insert_cassette("empty")
   expect_silent(x <- httr::GET("https://httpbin.org/get"))
+  vcr::eject_cassette("empty")
   expect_is(x, "response")
 })
 
@@ -353,4 +354,3 @@ test_that("httr requests with JSON-encoded bodies work", {
     "Unregistered request"
   )
 })
-


### PR DESCRIPTION
No more `empty.yml`s. 