### PR TITLE
add StubCounter to pkgdown config

### DIFF
--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -49,6 +49,6 @@ reference:
       - RequestPattern
       - RequestSignature
       - HashCounter
+      - StubCounter
       - pluck_body
       - Response
-      - StubCounter

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -27,7 +27,6 @@ reference:
       - StubbedRequest
       - stub_request
       - remove_request_stub
-      - StubCounter
       - to_raise
       - to_return
       - to_timeout
@@ -52,3 +51,4 @@ reference:
       - HashCounter
       - pluck_body
       - Response
+      - StubCounter

--- a/_pkgdown.yml
+++ b/_pkgdown.yml
@@ -27,6 +27,7 @@ reference:
       - StubbedRequest
       - stub_request
       - remove_request_stub
+      - StubCounter
       - to_raise
       - to_return
       - to_timeout


### PR DESCRIPTION
We see

```r
> pkgdown::check_pkgdown()
Error in `check_missing_topics()` at pkgdown/R/build-reference-index.R:16:2:
! All topics must be included in reference index
✖ Missing topics: StubCounter
ℹ Either add to _pkgdown.yml or use @keywords internal
```

Maybe I didn't put the function in the correct section, I tried guessing :smile_cat: 