### PR TITLE
Tweak how httr2 mocking function is set

### DIFF
--- a/R/adapter-httr2.R
+++ b/R/adapter-httr2.R
@@ -101,12 +101,8 @@ build_httr2_request <- function(x) {
 httr2_mock <- function(on = TRUE) {
   check_installed("httr2")
   if (on) {
-    httr2::local_mocked_responses(
-      ~ Httr2Adapter$new()$handle_request(.x),
-      env = .GlobalEnv
-    )
+    options(httr2_mock = function(req) Httr2Adapter$new()$handle_request(req))
   } else {
-    httr2::local_mocked_responses(NULL, env = .GlobalEnv)
     options(httr2_mock = NULL)
   }
   invisible(on)


### PR DESCRIPTION
There's no need to use `local_` here since you're not setting it locally and this avoids a slightly confusing message from withr:

```R
webmockr::enable()
#> CrulAdapter enabled!
#> HttrAdapter enabled!
#> Httr2Adapter enabled!
#> Setting global deferred event(s).
#> i These will be run:
#>   * Automatically, when the R session ends.
#>   * On demand, if you call `withr::deferred_run()`.
#> i Use `withr::deferred_clear()` to clear them without executing.
```

(In principle, it would be better if webmockr could restore the previous state prior to its mocking, but it's not a big deal given that there are very few other tools that do web mocking).

<!--- Provide a general summary of your changes in the Title above -->

## Description
<!--- Describe your changes in detail -->

## Related Issue
<!--- if this closes an issue make sure include e.g., "fix #4"
or similar - or if just relates to an issue make sure to mention
it like "#4" -->

## Example
<!--- if introducing a new feature or changing behavior of existing
methods/functions, include an example if possible to do in brief form -->

<!--- Did you remember to include tests? Unless you're just changing
grammar, please include new tests for your change -->
